### PR TITLE
ci(GitHub Actions): add Steam credentials as build arguments and secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          secrets: |
+            STEAM_USERNAME=${{ secrets.STEAM_USERNAME }}
+            STEAM_PASSWORD=${{ secrets.STEAM_PASSWORD }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:12-slim
 LABEL org.opencontainers.image.source=https://github.com/HoshinoRei/l4d2server-docker
 LABEL L4D2_VERSION=2242
+ARG STEAM_USERNAME
+ARG STEAM_PASSWORD
 RUN apt-get update && \
     apt-get install -y wget lib32gcc-s1 && \
     apt-get clean && \
@@ -11,7 +13,7 @@ WORKDIR /home/steam
 RUN wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz && \
     tar -xzf steamcmd_linux.tar.gz && \
     rm -rf steamcmd_linux.tar.gz && \
-    ./steamcmd.sh +force_install_dir /home/steam/l4d2server +login anonymous +app_update 222860 validate +quit && \
+    ./steamcmd.sh +force_install_dir /home/steam/l4d2server +login $STEAM_USERNAME $STEAM_PASSWORD +app_update 222860 validate +quit && \
     rm -rf /home/steam/l4d2server/left4dead2/host.txt \
         /home/steam/l4d2server/left4dead2/motd.txt
 EXPOSE 27015 27015/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:12-slim
 LABEL org.opencontainers.image.source=https://github.com/HoshinoRei/l4d2server-docker
 LABEL L4D2_VERSION=2242
-ARG STEAM_USERNAME
-ARG STEAM_PASSWORD
+RUN --mount=type=secret,id=STEAM_USERNAME,env=STEAM_USERNAME
+RUN --mount=type=secret,id=STEAM_PASSWORD,env=STEAM_PASSWORD
 RUN apt-get update && \
     apt-get install -y wget lib32gcc-s1 && \
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM debian:12-slim
 LABEL org.opencontainers.image.source=https://github.com/HoshinoRei/l4d2server-docker
 LABEL L4D2_VERSION=2242
-RUN --mount=type=secret,id=STEAM_USERNAME,env=STEAM_USERNAME
-RUN --mount=type=secret,id=STEAM_PASSWORD,env=STEAM_PASSWORD
 RUN apt-get update && \
     apt-get install -y wget lib32gcc-s1 && \
     apt-get clean && \
@@ -10,7 +8,9 @@ RUN apt-get update && \
     adduser --home /home/steam --disabled-password --shell /bin/bash --gecos "user for running steam" --quiet steam
 USER steam
 WORKDIR /home/steam
-RUN wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz && \
+RUN --mount=type=secret,id=STEAM_USERNAME,env=STEAM_USERNAME \
+    --mount=type=secret,id=STEAM_PASSWORD,env=STEAM_PASSWORD \
+    wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz && \
     tar -xzf steamcmd_linux.tar.gz && \
     rm -rf steamcmd_linux.tar.gz && \
     ./steamcmd.sh +force_install_dir /home/steam/l4d2server +login $STEAM_USERNAME $STEAM_PASSWORD +app_update 222860 validate +quit && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM debian:12-slim
 LABEL org.opencontainers.image.source=https://github.com/HoshinoRei/l4d2server-docker
 LABEL L4D2_VERSION=2242


### PR DESCRIPTION
- Added `STEAM_USERNAME` and `STEAM_PASSWORD` as build arguments in `Dockerfile`
- Updated the SteamCMD login command to use the provided credentials instead of anonymous login
- Added `STEAM_USERNAME` and `STEAM_PASSWORD` to GitHub Actions secrets for secure use during the build process