### PR TITLE
chore(Dockerfile): add locale generation for UTF-8 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8 && \
+    update-locale en_US.UTF-8 && \
     adduser --home /home/steam --disabled-password --shell /bin/bash --gecos "user for running steam" --quiet steam
 USER steam
 WORKDIR /home/steam

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && \
     locale-gen en_US.UTF-8 && \
     update-locale en_US.UTF-8 && \
     adduser --home /home/steam --disabled-password --shell /bin/bash --gecos "user for running steam" --quiet steam
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
 USER steam
 WORKDIR /home/steam
 RUN wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12-slim
 LABEL org.opencontainers.image.source=https://github.com/HoshinoRei/l4d2server-docker
 LABEL L4D2_VERSION=2243
 RUN apt-get update && \
-    apt-get install -y locale wget lib32gcc-s1 && \
+    apt-get install -y locales wget lib32gcc-s1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     locale-gen en_US.UTF-8 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM debian:12-slim
 LABEL org.opencontainers.image.source=https://github.com/HoshinoRei/l4d2server-docker
 LABEL L4D2_VERSION=2243
 RUN apt-get update && \
-    apt-get install -y wget lib32gcc-s1 && \
+    apt-get install -y locale wget lib32gcc-s1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    locale-gen en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8 && \
     adduser --home /home/steam --disabled-password --shell /bin/bash --gecos "user for running steam" --quiet steam
 USER steam
 WORKDIR /home/steam


### PR DESCRIPTION
- Install `locales` package in Docker image
- Generate `en_US.UTF-8` locale and set it as the default locale
- Ensure compatibility with systems requiring UTF-8 encoding
- set environment variables for locale