### PR TITLE
ci(GitHub Actions): update step name for Docker login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
- Changed step name from "Login to DockerHub" to "Login to Docker Hub" in `.github/workflows/build.yml`
- This improves consistency with the naming convention used in the Docker documentation