### PR TITLE
ci(GitHub Actions): replace Docker Hub username secret with environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
     tags:
       - "v*"
 env:
+  DOCKERHUB_USERNAME: hoshinorei
   GITHUB_CONTAINER_REGISTRY_DOMAIN: ghcr.io
   IMAGE_NAME: l4d2server
 jobs:
@@ -25,7 +26,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -38,7 +39,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
             ${{ env.GITHUB_CONTAINER_REGISTRY_DOMAIN }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
           tags: |
             type=edge,branch=master


### PR DESCRIPTION
- Defined `DOCKERHUB_USERNAME` environment variable in GitHub Actions workflow
- Replaced `DOCKERHUB_USERNAME` secret with `${{ env.DOCKERHUB_USERNAME }}` in login and metadata actions to use the new environment variable