### PR TITLE
ci(GitHub Actions): Add the `sha` type to the image tag in `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
             type=edge,branch=master
             type=ref,event=pr
             type=ref,event=tag
+            type=sha,format=long
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
- In the `Generate metadata` step of `Build Docker Image` job, add a long `sha` type to the generated tags