### PR TITLE
docs(readme): add commented line for alternate image source

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ services:
     command: "-secure +exec server.cfg +map c1m1_hotel -port 27015"
     container_name: l4d2server
     image: hoshinorei/l4d2server:edge
+    # image: ghcr.io/hoshinorei/l4d2server:edge
     ports:
       - 27015:27015
       - 27015:27015/udp


### PR DESCRIPTION
- Added a commented line for using the `ghcr.io/hoshinorei/l4d2server:edge` image as an alternative to the existing image.
- This provides users with an option to switch the image source if needed, enhancing flexibility in deployment.