### PR TITLE
ci(GitHub Actions): use the correct reference as the image name in the `build.yml` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: |
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
-            ${{ env.GITHUB_CONTAINER_REGISTRY_DOMAIN }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
+            ${{ env.GITHUB_CONTAINER_REGISTRY_DOMAIN }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=edge,branch=master
             type=ref,event=pr


### PR DESCRIPTION
- Change `${{ github.actor }}` to `${{ github.repository_owner }}` to correctly obtain the repository owner's name for image tagging