### PR TITLE
chore(Dockerfile): remove volume mount for `/home/steam/l4d2server/left4dead2/addons`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz 
     rm -rf /home/steam/l4d2server/left4dead2/host.txt \
         /home/steam/l4d2server/left4dead2/motd.txt
 EXPOSE 27015 27015/udp
-VOLUME /home/steam/l4d2server/left4dead2/addons \
-    /home/steam/l4d2server/left4dead2/cfg/server.cfg \
+VOLUME /home/steam/l4d2server/left4dead2/cfg/server.cfg \
     /home/steam/l4d2server/left4dead2/motd.txt \
     /home/steam/l4d2server/left4dead2/host.txt
 ENTRYPOINT ["/home/steam/l4d2server/srcds_run", "-game left4dead2"]


### PR DESCRIPTION
This change removes the volume mount for the `/home/steam/l4d2server/left4dead2/addons` directory to considering that the derivative images of this image may use SourceMod.

The volume mounts for `server.cfg`, `motd.txt`, and `host.txt` remain unchanged.