### PR TITLE
ci(GitHub Actions): configure CI job permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ env:
 jobs:
   build_docker_image:
     name: Build Docker Image
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This commit adds necessary permissions to the CI job to allow read access to repository contents and write access to packages. These permissions are required for certain CI tasks, such as publishing packages or accessing other repository resources.